### PR TITLE
Add a configurable DEFAULT_TIMEOUT for web3 nodes requests

### DIFF
--- a/src/karpatkit/__init__.py
+++ b/src/karpatkit/__init__.py
@@ -1,0 +1,1 @@
+from defabipedia import Chain  # noqa

--- a/src/karpatkit/node.py
+++ b/src/karpatkit/node.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import warnings
 
 import requests
@@ -12,6 +13,13 @@ from . import cache
 from .helpers import get_config
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = float(os.environ.get("KKIT_NODE_TIMEOUT", 30))
+
+
+def reset_providers():
+    global _nodes_providers
+    _nodes_providers = dict()
 
 
 class AllProvidersDownError(Exception):
@@ -34,7 +42,7 @@ class ProviderManager(JSONBaseProvider):
             if "://" not in url:
                 logger.warning(f"Skipping invalid endpoint URI '{url}'.")
                 continue
-            provider = HTTPProvider(url)
+            provider = HTTPProvider(url, request_kwargs={"timeout": DEFAULT_TIMEOUT})
             errors = []
             self.providers.append((provider, errors))
 

--- a/src/karpatkit/tests/test_node.py
+++ b/src/karpatkit/tests/test_node.py
@@ -1,0 +1,10 @@
+from karpatkit import Chain, node
+
+
+def test_change_timeout(monkeypatch):
+    monkeypatch.setattr(node, "DEFAULT_TIMEOUT", 7)
+    monkeypatch.setattr(node, "_nodes_providers", {})
+    node.reset_providers()
+    w3 = node.get_node(Chain.ETHEREUM)
+    w3.eth.get_block(1)
+    assert w3.provider.providers[0][0].get_request_kwargs()["timeout"] == 7


### PR DESCRIPTION
The current DEFAULT_TIMEOUT is 30 seconds.

There are two ways of changing the `DEFAULT_TIMEOUT`:
- setting the env var `KKIT_NODE_TIMEOUT` with a string representing a `float` or `int` number in seconds;
- in runtime from within the python process.
```python
from karpatkit import node
node.DEFAULT_TIMEOUT = 58.9
node.reset_providers()  # to avoid having already created providers with an old DEFAULT_TIMEOUT
```