### PR TITLE
Add eth_getBlockByNumber to the cache

### DIFF
--- a/src/karpatkit/cache.py
+++ b/src/karpatkit/cache.py
@@ -62,6 +62,7 @@ def disk_cache_middleware(make_request, web3):
         "eth_getTransactionByHash",
         "eth_getCode",
         "eth_getStorageAt",
+        "eth_getBlockByNumber",
     }
 
     def middleware(method, params):


### PR DESCRIPTION
Assuming the block is immutable, this method can be cached. This accelerate repeated requesting for the same block, specially used to find the timestime of a block, o to search a block near a timestime.